### PR TITLE
add a `-p` option for configuring the number of parallel workers to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ $ runtests -h
 Usage: runtests [options] [TESTS]
 
 Options:
-    -s, --seed-value SEED-VALUE      use a given seed to run tests
+    -s, --seed-value VALUE           use a given seed to run tests
     -c, --[no-]changed-only          only run test files with changes
-    -r, --changed-ref CHANGED-REF    reference for changes, use with `-c` opt
+    -r, --changed-ref VALUE          reference for changes, use with `-c` opt
+    -p, --parallel-workers VALUE     number of parallel workers to use (if applicable)
     -v, --[no-]verbose               output verbose runtime test info
         --[no-]dry-run               output the test command to $stdout
     -l, --[no-]list                  list test files on $stdout
@@ -99,6 +100,15 @@ SEED=23940 MINITEST_REPORTER=ProgressReporter ./bin/rake test test/thing1_test.r
 
 This option only outputs the test command it would have run.  It does not execute the test command.
 
+#### Parallel Workers
+
+```
+$ runtests -p 2 --dry-run
+SEED=23940 PARALLEL_WORKERS=2 MINITEST_REPORTER=ProgressReporter ./bin/rake test test/thing1_test.rb test/thing2_test.rb
+```
+
+Force a specific number of parallel workers to run the tests. This uses the configured `PARALLEL_ENV_VAR_NAME` constant to build the env var.
+
 #### List
 
 ```
@@ -145,12 +155,14 @@ module ATestRunner
   VERSION = "x.x.x"
 
   # update these as needed for your test setup
-  BIN_NAME           = "runtests" # should match what you name the executable
-  TEST_DIR           = "test"
-  TEST_FILE_SUFFIXES = ["_test.rb"]
-  TERSE_TEST_CMD     = "MINITEST_REPORTER=ProgressReporter ./bin/rake test"
-  VERBOSE_TEST_CMD   = "MINITEST_REPORTER=SpecReporter ./bin/rake test"
-  SEED_ENV_VAR_NAME  = "SEED"
+  BIN_NAME              = "runtests" # should match what you name the executable
+  TEST_DIR              = "test"
+  TEST_FILE_SUFFIXES    = ["_test.rb"]
+  TERSE_TEST_CMD        = "MINITEST_REPORTER=ProgressReporter ./bin/rails test"
+  VERBOSE_TEST_CMD      = "MINITEST_REPORTER=SpecReporter ./bin/rails test"
+  SEED_ENV_VAR_NAME     = "SEED"
+  PARALLEL_ENV_VAR_NAME = "PARALLEL_WORKERS"
+  ENV_VARS              = "USE_SIMPLE_COV=0"
 
 # ...
 ```
@@ -162,9 +174,10 @@ $ runtests -h
 Usage: runtests [options] [TESTS]
 
 Options:
-    -s, --seed-value SEED-VALUE      use a given seed to run tests
+    -s, --seed-value VALUE           use a given seed to run tests
     -c, --[no-]changed-only          only run test files with changes
-    -r, --changed-ref CHANGED-REF    reference for changes, use with `-c` opt
+    -r, --changed-ref VALUE          reference for changes, use with `-c` opt
+    -p, --parallel-workers VALUE     number of parallel workers to use (if applicable)
     -v, --[no-]verbose               output verbose runtime test info
         --[no-]dry-run               output the test command to $stdout
     -l, --[no-]list                  list test files on $stdout

--- a/a-test-runner.rb
+++ b/a-test-runner.rb
@@ -325,6 +325,7 @@ module ATestRunner
 
   def self.run
     begin
+      bench("ARGV parse and configure"){ apply(ARGV) }
       Runner.new(self.clirb.args, config: self.config).run
     rescue CLIRB::HelpExit
       self.config.puts self.help_msg
@@ -350,6 +351,5 @@ module ATestRunner
 end
 
 unless ENV["A_TEST_RUNNER_DISABLE_RUN"]
-  ATestRunner.bench("ARGV parse and configure"){ ATestRunner.apply(ARGV) }
   ATestRunner.run
 end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -22,8 +22,8 @@ class ATestRunner::Config
 
     should have_readers :stdout, :bin_name, :version, :test_dir, :test_file_suffixes
     should have_readers :default_test_cmd, :verbose_test_cmd
-    should have_readers :seed_env_var_name, :env_vars
-    should have_imeths  :seed_value, :changed_only, :changed_ref
+    should have_readers :parallel_env_var_name, :seed_env_var_name, :env_vars
+    should have_imeths  :seed_value, :changed_only, :changed_ref, :parallel_workers
     should have_imeths  :verbose, :dry_run, :list, :debug
     should have_imeths  :apply
     should have_imeths :debug_msg, :debug_puts, :puts, :print
@@ -38,45 +38,49 @@ class ATestRunner::Config
     end
 
     should "know its CONTANT driven attrs" do
-      assert_equal ATestRunner::BIN_NAME,           subject.bin_name
-      assert_equal ATestRunner::VERSION,            subject.version
-      assert_equal ATestRunner::TEST_DIR,           subject.test_dir
-      assert_equal ATestRunner::TEST_FILE_SUFFIXES, subject.test_file_suffixes
-      assert_equal ATestRunner::DEFAULT_TEST_CMD,   subject.default_test_cmd
-      assert_equal ATestRunner::VERBOSE_TEST_CMD,   subject.verbose_test_cmd
-      assert_equal ATestRunner::SEED_ENV_VAR_NAME,  subject.seed_env_var_name
-      assert_equal ATestRunner::ENV_VARS,           subject.env_vars
+      assert_equal ATestRunner::BIN_NAME,              subject.bin_name
+      assert_equal ATestRunner::VERSION,               subject.version
+      assert_equal ATestRunner::TEST_DIR,              subject.test_dir
+      assert_equal ATestRunner::TEST_FILE_SUFFIXES,    subject.test_file_suffixes
+      assert_equal ATestRunner::DEFAULT_TEST_CMD,      subject.default_test_cmd
+      assert_equal ATestRunner::VERBOSE_TEST_CMD,      subject.verbose_test_cmd
+      assert_equal ATestRunner::PARALLEL_ENV_VAR_NAME, subject.parallel_env_var_name
+      assert_equal ATestRunner::SEED_ENV_VAR_NAME,     subject.seed_env_var_name
+      assert_equal ATestRunner::ENV_VARS,              subject.env_vars
     end
 
     should "default its settings attrs" do
       assert_not_nil subject.seed_value
       assert_false   subject.changed_only
       assert_empty   subject.changed_ref
+      assert_nil     subject.parallel_workers
       assert_false   subject.verbose
       assert_false   subject.dry_run
       assert_false   subject.list
       assert_false   subject.debug
     end
 
-    should "allow apply custom settings attrs" do
+    should "allow applying custom settings attrs" do
       settings = {
-        :seed_value   => Factory.integer,
-        :changed_only => true,
-        :changed_ref  => Factory.string,
-        :verbose      => true,
-        :dry_run      => true,
-        :list         => true,
-        :debug        => true
+        :seed_value       => Factory.integer,
+        :changed_only     => true,
+        :changed_ref      => Factory.string,
+        :parallel_workers => Factory.integer(3),
+        :verbose          => true,
+        :dry_run          => true,
+        :list             => true,
+        :debug            => true
       }
       subject.apply(settings)
 
-      assert_equal settings[:seed_value],   subject.seed_value
-      assert_equal settings[:changed_only], subject.changed_only
-      assert_equal settings[:changed_ref],  subject.changed_ref
-      assert_equal settings[:verbose],      subject.verbose
-      assert_equal settings[:dry_run],      subject.dry_run
-      assert_equal settings[:list],         subject.list
-      assert_equal settings[:debug],        subject.debug
+      assert_equal settings[:seed_value],       subject.seed_value
+      assert_equal settings[:changed_only],     subject.changed_only
+      assert_equal settings[:changed_ref],      subject.changed_ref
+      assert_equal settings[:parallel_workers], subject.parallel_workers
+      assert_equal settings[:verbose],          subject.verbose
+      assert_equal settings[:dry_run],          subject.dry_run
+      assert_equal settings[:list],             subject.list
+      assert_equal settings[:debug],            subject.debug
     end
 
     should "know how to build debug messages" do


### PR DESCRIPTION
This is especially needed when in e.g. Rails 6 you are trying to
use the pry debugger to look at a broken test. If you try to pry
with multiple workers, Pry breaks b/c multiple threads pry at the
same time.

This option allows you to set a `-p 1` to force a single worker
and pry debug as you normally would.

### fix a bug in printing the help message with the `-h` option

This was caused b/c the command parsing was executing outside of
the command parsing rescues. I messed this up when I previously
reworked how the options were parsed.